### PR TITLE
Other plugins declare loader too

### DIFF
--- a/chrome/content/autozotbib/include.js
+++ b/chrome/content/autozotbib/include.js
@@ -1,6 +1,6 @@
 // Only create main object once
 if (!Zotero.AutoZotBib) {
-	const loader = Components.classes["@mozilla.org/moz/jssubscript-loader;1"]
+	var loader = Components.classes["@mozilla.org/moz/jssubscript-loader;1"]
 					.getService(Components.interfaces.mozIJSSubScriptLoader);
 	loader.loadSubScript("chrome://autozotbib/content/autozotbib.js");
 }


### PR DESCRIPTION
Declaring to const causes a loading order problem.
